### PR TITLE
see if the receiver delay can be removed

### DIFF
--- a/chat.ino
+++ b/chat.ino
@@ -28,7 +28,7 @@ void loop() {
                 vw_wait_tx();
         }
         // Read the received data
-        vw_wait_rx_max(10);                             
+        //vw_wait_rx_max(10);                             // can we commment this out?
         if (vw_get_message(buf, &buflen)){
                 int i;
                 for (i = 0; i < buflen; i++){

--- a/chat.ino
+++ b/chat.ino
@@ -32,7 +32,7 @@ void loop() {
         if (vw_get_message(buf, &buflen)){
                 //int i;
                 //for (i = 0; i < buflen; i++){
-                    Serial.write(buf[1]);
+                    Serial.write(buf[0]);
                 //}     
     }
 }

--- a/chat.ino
+++ b/chat.ino
@@ -30,9 +30,9 @@ void loop() {
         // Read the received data
         //vw_wait_rx_max(10);                             // can we commment this out?
         if (vw_get_message(buf, &buflen)){
-                int i;
-                for (i = 0; i < buflen; i++){
-                    Serial.write(buf[i]);
-                }     
+                //int i;
+                //for (i = 0; i < buflen; i++){
+                    Serial.write(buf[1]);
+                //}     
     }
 }


### PR DESCRIPTION
Needs testing, but as loop() will run multiple times per word, why not? 
